### PR TITLE
Added padding to navigation

### DIFF
--- a/src/devdocs2zim/templates/page.html
+++ b/src/devdocs2zim/templates/page.html
@@ -11,6 +11,15 @@
     <meta charset="utf-8">
     <title>{{title}}</title>
     <link rel="stylesheet" type="text/css" href="{{rel_prefix | safe}}application.css" />
+    <style type="text/css">
+        /* Make the <details> tag based navigation match the look and feel of devdocs.io. */
+        ._list-count, ._list-enable {
+            margin-right: .375rem;
+        }
+        ._list-item {
+            padding: .25rem;
+        }
+    </style>
 </head>
 <body>
     <div class="_app">


### PR DESCRIPTION
Fixes padding around numbers in the navbar and the extra white space before navigation items.

Before:
![image](https://github.com/user-attachments/assets/3326d4ce-bba6-42e2-aeb3-6f31e9005419)


After:

![image](https://github.com/user-attachments/assets/668092af-553f-4bf1-8331-f92357042907)

Fixes #18