### PR TITLE
Fixed navigation oddities with single page docs

### DIFF
--- a/src/devdocs2zim/client.py
+++ b/src/devdocs2zim/client.py
@@ -148,8 +148,15 @@ class NavigationSection(BaseModel):
     def _contained_pages(self) -> set[str]:
         return {link.path_without_fragment for link in self.links}
 
-    def contains_page(self, page_path: str) -> bool:
-        """Returns whether this section contains the given page."""
+    def opens_for_page(self, page_path: str) -> bool:
+        """Returns whether this section should be rendered open for the given page."""
+
+        # Some docs like Lua or CoffeeScript have all of their content in the index.
+        # Others like RequireJS are split between index and additional pages.
+        # We don't want sections opening when the user navigates to the index.
+        if page_path == "index":
+            return False
+
         return page_path in self._contained_pages
 
 

--- a/src/devdocs2zim/templates/page.html
+++ b/src/devdocs2zim/templates/page.html
@@ -29,7 +29,7 @@
                 <a href="{{rel_prefix | safe}}index" class="_list-item">{{devdocs_metadata.name}}</a>
                 <div class="_list">
                     {% for section in nav_sections %}
-                    <details {% if section.contains_page(path) %}open{% endif %}>
+                    <details {% if section.opens_for_page(path) %}open{% endif %}>
                         <summary>
                             <span class="_list-item" style="display:inline; box-shadow: none;">
                                 <span class="_list-count">{{ section.count | safe}}</span>

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -280,7 +280,7 @@ class TestNavigationSection(TestCase):
 
         self.assertEqual(1, got)
 
-    def test_contains_page(self):
+    def test_opens_for_page(self):
         section = NavigationSection(
             name="",
             links=[
@@ -290,9 +290,20 @@ class TestNavigationSection(TestCase):
             ],
         )
 
-        self.assertTrue(section.contains_page("foo"))
-        self.assertTrue(section.contains_page("bar"))
-        self.assertFalse(section.contains_page("bazz"))
+        self.assertTrue(section.opens_for_page("foo"))
+        self.assertTrue(section.opens_for_page("bar"))
+        self.assertFalse(section.opens_for_page("bazz"))
+
+    def test_opens_for_page_index(self):
+        section = NavigationSection(
+            name="",
+            links=[
+                DevdocsIndexEntry(name="Index", path="index", type=None),
+            ],
+        )
+
+        # Links to the index are special cases and shouldn't open.
+        self.assertFalse(section.opens_for_page("index"))
 
 
 class TestDevdocsIndex(TestCase):


### PR DESCRIPTION
Fixes #16. Changes the logic for expanding sections to ignore the special case of the index. Example showing Lua now works:

![image](https://github.com/user-attachments/assets/43ed584b-5760-4bb3-ad5f-2687fe825832)

I additionally validated RequireJS which has much of its content in the index but other parts in different pages, it behaves as expected.

A longer term, better fix for this is #24.