### PR TITLE
fix: stop scraper from finishing ZIM when bad exception arises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Stop scraper from finishing ZIM when bad exception arises. (#55)
+
 ## [0.2.0] - 2024-11-14
 
 ### Added

--- a/src/devdocs2zim/generator.py
+++ b/src/devdocs2zim/generator.py
@@ -497,21 +497,27 @@ class Generator:
 
         # Start creator early to detect problems early.
         with creator as started_creator:
-            logger.info("  Fetching the index...")
-            index = self.devdocs_client.get_index(doc_metadata.slug)
-            logger.debug(f"  The index has {len(index.entries)} entries.")
+            try:
+                logger.info("  Fetching the index...")
+                index = self.devdocs_client.get_index(doc_metadata.slug)
+                logger.debug(f"  The index has {len(index.entries)} entries.")
 
-            logger.info("  Fetching the document database...")
-            db = self.devdocs_client.get_db(doc_metadata.slug)
-            logger.debug(f"  The database has {len(db)} entries.")
+                logger.info("  Fetching the document database...")
+                db = self.devdocs_client.get_db(doc_metadata.slug)
+                logger.debug(f"  The database has {len(db)} entries.")
 
-            self.add_zim_contents(
-                creator=started_creator,
-                doc_metadata=doc_metadata,
-                index=index,
-                db=db,
-                common_resources=common_resources,
-            )
+                self.add_zim_contents(
+                    creator=started_creator,
+                    doc_metadata=doc_metadata,
+                    index=index,
+                    db=db,
+                    common_resources=common_resources,
+                )
+            except Exception:
+                started_creator.can_finish = False
+
+                raise
+
         return zim_path
 
     @staticmethod

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -471,3 +471,16 @@ class TestGenerator(TestCase):
 
     def test_fetch_logo_bytes_returns_none_fails(self):
         self.assertRaises(Exception, Generator.fetch_logo_bytes, "")
+
+    def test_generate_zim_cleans_up_on_failure(self):
+        doc_metadata = DevdocsMetadata(name="MockDoc", slug="mockdoc")
+
+        self.mock_client.get_db.side_effect = RuntimeError("Simulated network timeout")
+
+        with self.assertRaises(RuntimeError):
+            self.generator.generate_zim(doc_metadata, [])
+
+        output_dir = Path(self.generator.output_folder)
+        zims = list(output_dir.glob("*.zim"))
+
+        self.assertEqual(0, len(zims))


### PR DESCRIPTION
fixes #54 
### Changes
* Wrapped the ZIM creation context manager in a `try...except Exception:` block inside `generator.py`.

* If an exception occurs, delete the incomplete ZIM file and
bubble the exception to `entrypoint` and exit with code 1

* Added `test_generate_zim_cleans_up_on_failure` to `tests/test_generator.py` to ensure the file is deleted and the exception is propagated when `get_db` fails.